### PR TITLE
Add first in line prompt

### DIFF
--- a/src/controllers/messages/handlers.js
+++ b/src/controllers/messages/handlers.js
@@ -103,7 +103,7 @@ function handleQuickReply(recipient, message) {
       case "skip-faq":
         return seller.promptStart(recipient, t.faq.no_faq + t.general.next);
       case "setup-queue":
-        listings.setQueue(listingId, true);
+        listings.createQueue(listingId);
         await send.text(recipient, "A queue has been sucessfuly set up.");
         return seller.promptSetupFAQ(recipient);
       case "add-queue":

--- a/src/controllers/messages/rooms.js
+++ b/src/controllers/messages/rooms.js
@@ -1,6 +1,6 @@
 const { db } = require("../../db");
 const { send } = require("../../client");
-const t = require("../../../copy.json");
+const t = require("../../copy.json");
 
 async function makeRoom(listingId, members) {
   const roomsRef = db.ref("rooms");

--- a/src/controllers/messages/rooms.js
+++ b/src/controllers/messages/rooms.js
@@ -1,5 +1,6 @@
 const { db } = require("../../db");
 const { send } = require("../../client");
+const listings = require("../../db/listings");
 const t = require("../../copy.json");
 
 async function makeRoom(listingId, members) {

--- a/src/controllers/messages/users/buyer.js
+++ b/src/controllers/messages/users/buyer.js
@@ -148,6 +148,7 @@ async function removeUserFromQueue(recipient, listingId, title) {
   if (position < 0) {
     send.text(recipient, t.buyer.not_in_queue);
   } else {
+    queue.splice(position, 1);
     const updates = [];
     updates.push(
       send
@@ -174,7 +175,6 @@ async function removeUserFromQueue(recipient, listingId, title) {
       );
     }
     await Promise.all(updates);
-    queue.splice(position, 1);
     listingRef.child("queue").set(queue);
   }
 }

--- a/src/controllers/messages/users/buyer.js
+++ b/src/controllers/messages/users/buyer.js
@@ -126,7 +126,9 @@ async function addUserToQueue(recipient, listingId) {
   }
 
   await Promise.all(updates);
-  promptNextAction(recipient, listingId);
+  if (queue.length > 1) {
+    promptNextAction(recipient, listingId);
+  }
   await send.text({ id: seller }, `Someone joined the queue for ${title}!`);
   return send.text({ id: seller }, getUpdatedSellerQueueMessage(queue, title));
 }

--- a/src/copy.json
+++ b/src/copy.json
@@ -16,7 +16,9 @@
     "buyer_warning": "You haven't replied in 24 hours! Reply within the next 24 hours to keep your position in line.",
     "buyer_danger": "It's been 48 hours since the seller messaged you! Unfortunately, this means you will get kicked out of the queue.",
     "seller_warning": "You haven't replied in 24 hours! Be sure to reply soon!",
-    "seller_danger": "It's been 48 hours since the buyer messaged you! Be sure to reply soon!"
+    "seller_danger": "It's been 48 hours since the buyer messaged you! Be sure to reply soon!",
+    "general_warning": "It's been 24 hours!",
+    "general_danger": "It's been 48 hours!"
   },
   "faq": {
     "question": "Would you like to setup a FAQ?",


### PR DESCRIPTION
- fixes #69 
- Prompt user to message seller when they become first in line
- Add checks to ensure they don't get asked again (when a user gets added to the queue for example)
  - Current way is very hacky, ideally we change the queue data structure in firebase