### PR TITLE
Fix bug with `show FAQ` command when no FAQ exists

### DIFF
--- a/src/controllers/messages/handlers.js
+++ b/src/controllers/messages/handlers.js
@@ -114,6 +114,8 @@ function handleQuickReply(recipient, message) {
         return seller.promptSetupFAQ(recipient);
       case "leave-queue":
         return buyer.removeUserFromQueue(recipient, listingId, title);
+      case "message-seller":
+        return handleText(recipient, { message: { text: "\\message seller" } });
       case "remove-listing":
         listings.removeListing(recipient.id, listingId);
         return seller.promptStart(recipient, t.seller.remove_listing);
@@ -124,7 +126,10 @@ function handleQuickReply(recipient, message) {
       case "show-faq": {
         const { queue = [], faq = [] } = listing;
         await send.text(recipient, buyer.formatFAQ(faq));
-        return buyer.promptInterestedBuyer(recipient, queue);
+        if (!queue.includes(recipient.id)) {
+          return buyer.promptInterestedBuyer(recipient, queue);
+        }
+        return buyer.notifyBuyerStatus(recipient, queue);
       }
       case "quit":
         // TODO

--- a/src/controllers/messages/users/buyer.js
+++ b/src/controllers/messages/users/buyer.js
@@ -13,11 +13,15 @@ const t = require("../../../copy.json");
  * @param {array} faq
  */
 function formatFAQ(faq) {
-  let formattedMessage = "";
-  for (const { question, answer } of faq) {
-    formattedMessage += `Question: ${question}\n` + `Answer: ${answer}\n\n`;
+  if (faq.length > 0) {
+    let formattedMessage = "";
+    for (const { question, answer } of faq) {
+      formattedMessage += `Question: ${question}\n` + `Answer: ${answer}\n\n`;
+    }
+    return formattedMessage.substring(0, -2);
+  } else {
+    return t.buyer.no_faq;
   }
-  return formattedMessage.substring(0, -2);
 }
 
 /**
@@ -30,7 +34,8 @@ function formatFAQ(faq) {
  * @param {array} queue
  */
 function promptInterestedBuyer(recipient, queue) {
-  const text = getQueueMessage(recipient.id, queue);
+  const queueMessage = getQueueMessage(recipient.id, queue);
+  const text = `${queueMessage} ${t.queue.buyer_question}`;
   const replies = [
     {
       content_type: "text",
@@ -48,9 +53,7 @@ function promptInterestedBuyer(recipient, queue) {
       payload: "skip-queue"
     }
   ];
-  send
-    .text(recipient, text)
-    .then(() => send.quickReplies(recipient, replies, t.queue.buyer_question));
+  return send.quickReplies(recipient, replies, text);
 }
 
 async function promptInterestedBuyerNoQueue(recipient, listing) {


### PR DESCRIPTION
- fixes #49 
- When no FAQ exists, we need to tell the user to message the seller directly

- When user chooses `Message seller` quick reply, the bot currently replies with `Not implemented`. We can re-route this quick reply as a text command by calling `handleText`.

- We also need to distinguish between when a user is in the queue vs. when they are not in the case of `show-faq`.